### PR TITLE
Allow users to find their account by email case-insensitive

### DIFF
--- a/backend/app/controllers/api/v1/passwords_controller.rb
+++ b/backend/app/controllers/api/v1/passwords_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::PasswordsController < ApplicationController
   end
 
   def create
-    user = User.find_by!(email: email_param)
+    user = User.find_by!("LOWER(email) = ?", email_param.downcase)
 
     return unless user.send_reset_password_instructions
 

--- a/backend/app/controllers/api/v1/passwords_controller.rb
+++ b/backend/app/controllers/api/v1/passwords_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::PasswordsController < ApplicationController
   end
 
   def create
-    user = User.find_by!("LOWER(email) = ?", email_param.downcase)
+    user = User.find_by!(email: email_param.downcase)
 
     return unless user.send_reset_password_instructions
 

--- a/backend/spec/controllers/api/v1/passwords_controller_spec.rb
+++ b/backend/spec/controllers/api/v1/passwords_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Api::V1::PasswordsController do
         }
       end
 
-      context "for an that email exists in the database" do
+      context "for an email that exists in the database" do
         it "returns a password reset object" do
           expect_any_instance_of(User).to receive(:send_reset_password_instructions).and_return true
           post :create, params: { password: password_params.merge(email: user.email) }

--- a/backend/spec/controllers/api/v1/passwords_controller_spec.rb
+++ b/backend/spec/controllers/api/v1/passwords_controller_spec.rb
@@ -12,22 +12,22 @@ RSpec.describe Api::V1::PasswordsController do
           email: nil,
           password: nil,
           password_confirmation: nil,
-          reset_password_token: nil,
+          reset_password_token: nil
         }
       end
 
       context "for an email that exists in the database" do
         it "returns a password reset object" do
           expect_any_instance_of(User).to receive(:send_reset_password_instructions).and_return true
-          post :create, params: { password: password_params.merge(email: user.email) }
+          post :create, params: {password: password_params.merge(email: user.email)}
           expect(response.status).to eq 200
           expect(response_body[:password]).to include({"email" => user.email})
         end
 
         it "finds a user by case-insensitive email address" do
-          other_user = create :user, email: "areallycamelcaseemail@gmail.com"
+          other_user = create :user, email: "arEALLycAMELcaSeemAIl@gmail.com"
           expect_any_instance_of(User).to receive(:send_reset_password_instructions).and_return true
-          post :create, params: { password: password_params.merge(email: "AReallyCamelCaseEmail@GmAiL.CoM") }
+          post :create, params: {password: password_params.merge(email: "AReallyCamelCaseEmail@GmAiL.CoM")}
           expect(response.status).to eq 200
           expect(response_body[:password]).to include({"email" => other_user.email})
         end
@@ -36,7 +36,7 @@ RSpec.describe Api::V1::PasswordsController do
       context "for an email that does not exist in the database" do
         it "returns a 404" do
           expect_any_instance_of(User).to_not receive(:send_reset_password_instructions)
-          post :create, params: { password: password_params.merge(email: "Idonotexist@example.com") }
+          post :create, params: {password: password_params.merge(email: "Idonotexist@example.com")}
           expect(response.status).to eq 404
         end
       end

--- a/backend/spec/controllers/api/v1/passwords_controller_spec.rb
+++ b/backend/spec/controllers/api/v1/passwords_controller_spec.rb
@@ -3,6 +3,46 @@ require "rails_helper"
 RSpec.describe Api::V1::PasswordsController do
   let(:user) { create(:user, password: "ValidPassword123", password_confirmation: "ValidPassword123") }
 
+  describe "create" do
+    context "when attempting to reset a password" do
+      let(:password_params) do
+        {
+          # Match the form posted by the front end
+          current_password: nil,
+          email: nil,
+          password: nil,
+          password_confirmation: nil,
+          reset_password_token: nil,
+        }
+      end
+
+      context "for an that email exists in the database" do
+        it "returns a password reset object" do
+          expect_any_instance_of(User).to receive(:send_reset_password_instructions).and_return true
+          post :create, params: { password: password_params.merge(email: user.email) }
+          expect(response.status).to eq 200
+          expect(response_body[:password]).to include({"email" => user.email})
+        end
+
+        it "finds a user by case-insensitive email address" do
+          other_user = create :user, email: "areallycamelcaseemail@gmail.com"
+          expect_any_instance_of(User).to receive(:send_reset_password_instructions).and_return true
+          post :create, params: { password: password_params.merge(email: "AReallyCamelCaseEmail@GmAiL.CoM") }
+          expect(response.status).to eq 200
+          expect(response_body[:password]).to include({"email" => other_user.email})
+        end
+      end
+
+      context "for an email that does not exist in the database" do
+        it "returns a 404" do
+          expect_any_instance_of(User).to_not receive(:send_reset_password_instructions)
+          post :create, params: { password: password_params.merge(email: "Idonotexist@example.com") }
+          expect(response.status).to eq 404
+        end
+      end
+    end
+  end
+
   describe "update" do
     context "when no user logged-in" do
       context "when missing token" do


### PR DESCRIPTION
One of the common support issues is that users try to reset their password, but get an error message because their account was not found. This is believed to often be caused by users typing their email address in with capital letters, even though all emails are stored in the database lower case.

This commit changes the user lookup to a case insensitive match, and adds test coverage for that.

In testing, we found that users who are created with mixed-case emails are stored in lower-case. I believe this is done by [Devise in its configuration](https://github.com/rubyforgood/Flaredown/blob/07602eb6999d281e77074e1fa3347158b391425e/backend/config/initializers/devise.rb#L44)

Closes #409 