### PR TITLE
Default to English when translation missing in API

### DIFF
--- a/backend/app/models/ranked_enum.rb
+++ b/backend/app/models/ranked_enum.rb
@@ -27,7 +27,10 @@ class RankedEnum
   end
 
   def name
-    I18n.t "#{key}.#{id}"
+    I18n.t! "#{key}.#{id}"
+  rescue I18n::MissingTranslationData
+    # This avoids strings in the UI like "translation missing: pt.sex.male"
+    I18n.t "#{key}.#{id}", locale: :en
   end
 
   def key


### PR DESCRIPTION
This avoids strings in the UI like "translation missing: pt.sex.male"

Fixes #487