### PR TITLE
Upgrades sidekiq to 6.2

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -30,7 +30,7 @@ gem "omniauth-facebook", "~> 3.0.0"
 gem "colored", "~> 1.2"
 
 # Background jobs
-gem "sidekiq", "5.2.0"
+gem "sidekiq", "~> 6.2"
 
 # Structured seed data
 gem "seedbank"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -280,8 +280,6 @@ GEM
     rack (2.2.3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
-    rack-protection (2.1.0)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rack-timeout (0.6.0)
@@ -366,10 +364,10 @@ GEM
       rake (>= 10.0)
     shoulda-matchers (5.0.0)
       activesupport (>= 5.2.0)
-    sidekiq (5.2.0)
-      connection_pool (~> 2.2, >= 2.2.2)
-      rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
+    sidekiq (6.2.2)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -472,7 +470,7 @@ DEPENDENCIES
   ruby-progressbar
   seedbank
   shoulda-matchers
-  sidekiq (= 5.2.0)
+  sidekiq (~> 6.2)
   simplecov
   standardrb
   symmetric-encryption
@@ -485,4 +483,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.2.17
+   2.2.29

--- a/backend/Procfile.local
+++ b/backend/Procfile.local
@@ -1,3 +1,3 @@
 web: bundle exec puma -C config/puma.rb
-worker: bundle exec sidekiq -C config/sidekiq.yml -L log/sidekiq.log
+worker: bundle exec sidekiq -C config/sidekiq.yml
 tunnel: bundle exec bin/localtunnel


### PR DESCRIPTION
Resolves redis-related deprecation warnings:

```
Redis#exists(key)` will return an Integer in redis-rb 4.3, if you want to keep the old behavior, use `exists?` instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer = true.
```
