### PR TITLE
Fix console errors when entering birth date

### DIFF
--- a/frontend/app/components/birth-date.js
+++ b/frontend/app/components/birth-date.js
@@ -10,7 +10,7 @@ export default Component.extend({
     let monthArray = [];
 
     for(let i = 1; i<= 12; i++) {
-      monthArray.push(i);
+      monthArray.push(i.toString());
     }
 
     return monthArray;
@@ -22,7 +22,7 @@ export default Component.extend({
     const startYear = this.get('startYear');
 
     for (let i=endYear; i>=startYear; i--) {
-      yearsArray.push(i);
+      yearsArray.push(i.toString());
     }
 
     return yearsArray;
@@ -40,7 +40,7 @@ export default Component.extend({
       const month = get(this, 'birthDate.month');
 
       for (let d = 1; d <= this.daysInMonth(month, year); d ++) {
-        days.push(d);
+        days.push(d.toString());
       }
     }
 


### PR DESCRIPTION
Resolves this error:
```
Assertion Failed: {{power-select}} If you want the default filtering to work on options that are not plain strings, you need to provide `searchField`
```

The problem is that the search field is expecting strings, but we are passing numbers. This is [documented as a requirement by Ember](https://ember-power-select.com/docs/the-search/) in the section "Customizing the search field"
![Screen Shot 2021-10-13 at 10 31 35 AM](https://user-images.githubusercontent.com/167131/137154277-13d67f1b-a0c6-431f-a27d-fb2679088e0a.png)

