### PR TITLE
Tests/posts controller specs

### DIFF
--- a/backend/app/controllers/api/v1/posts_controller.rb
+++ b/backend/app/controllers/api/v1/posts_controller.rb
@@ -8,7 +8,12 @@ class Api::V1::PostsController < ApplicationController
     else
       @posts = DiscussionPosts.new(params, current_user).show_list
 
-      render json: @posts.order(last_commented: :desc, created_at: :desc).page(params[:page]).per(10)
+      results = @posts
+        .includes([:comments, :notifications, :reactions])
+        .order(last_commented: :desc, created_at: :desc)
+        .page(params[:page])
+        .per(10)
+      render json: results
     end
   end
 

--- a/backend/app/models/post.rb
+++ b/backend/app/models/post.rb
@@ -58,6 +58,6 @@ class Post
   def topic_presence
     TOPIC_TYPES.each { |topic| return true if send(topic.pluralize).any? }
 
-    errors.add(:topics, "should have at list one entry")
+    errors.add(:topics, "should have at least one of associated #{TOPIC_TYPES.join(",")}")
   end
 end

--- a/backend/spec/controllers/api/v1/posts_controller_spec.rb
+++ b/backend/spec/controllers/api/v1/posts_controller_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::PostsController do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  before { sign_in user }
+
+  describe "index" do
+    it "returns a list of discussion posts" do
+      create(:post, user_id: user.id)
+      create(:post, user_id: other_user.id)
+      get :index
+      expect(response_body[:posts].size).to eq 2
+    end
+  end
+end

--- a/backend/spec/factories/posts.rb
+++ b/backend/spec/factories/posts.rb
@@ -1,7 +1,8 @@
 FactoryBot.define do
   factory :post do
-    title { "MyString" }
-    body { "MyString" }
-    user_id { 1 }
+    title { "Frustrating day" }
+    body { "Today was really hard with my symptoms" }
+    encrypted_user_id { "abcd1234" }
+    symptom_ids { [create(:symptom).id] }
   end
 end


### PR DESCRIPTION
Adds minimal spec coverage on a controller that previously had none. This should help ensure the chat function still works as we upgrade in the future.