### PR TITLE
added background color and color to filter buttons, matching styling throughout the page

### DIFF
--- a/frontend/app/styles/components/discussions.scss
+++ b/frontend/app/styles/components/discussions.scss
@@ -29,14 +29,14 @@
   }
 
   .btn-filter {
-    color: $lilaс;
+    color: $primary;
     padding: .5em 1em;
     background-color: transparent;
-    border: 1px solid $lilaс;
+    border: 1px solid $primary;
 
     &.active {
       color: white;
-      background-color: $lilaс;
+      background-color: $primary;
     }
   }
 }


### PR DESCRIPTION
Matched style guide for the buttons on posts page view.  This is part of issue #522 

Before:

![posts-before](https://user-images.githubusercontent.com/15971206/137335058-0792314d-ed42-401a-b1ec-d98ed2480824.png)

After


![posts-after](https://user-images.githubusercontent.com/15971206/137335127-90c1c797-faae-4141-ad87-142a6b09cdcb.png)


Thank you!

