### PR TITLE
Fix removing a reaction from a discussion post

### DIFF
--- a/backend/app/models/reaction.rb
+++ b/backend/app/models/reaction.rb
@@ -28,7 +28,7 @@ class Reaction
           id: (reactions_for_user[reaction["_id"]] || SecureRandom.hex(16)).to_s,
           value: reaction["_id"],
           count: reaction["count"],
-          participated: reactions_for_user.keys.include?(reaction["_id"])
+          participated: reactions_for_user.key?(reaction["_id"])
         }
       end
     end

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -24,7 +24,7 @@ module Flaredown
     config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins "*"
-        resource "*", headers: :any, methods: [:get, :post, :options, :put]
+        resource "*", headers: :any, methods: [:get, :post, :options, :put, :delete]
       end
     end
     # Settings in config/environments/* take precedence over those specified here.

--- a/backend/spec/models/reaction_spec.rb
+++ b/backend/spec/models/reaction_spec.rb
@@ -11,17 +11,21 @@ describe Reaction do
 
   context "#values_count_with_participated" do
     it "should indicate counts and when the given user has already used the requested reaction" do
-      create(:reaction, encrypted_user_id: user.encrypted_id, value: ":smile:")
+      reaction = create(:reaction, encrypted_user_id: user.encrypted_id, value: ":smile:")
       create(:reaction, encrypted_user_id: other_user.encrypted_id, value: ":smile:")
       create(:reaction, encrypted_user_id: other_user.encrypted_id, value: ":smirk:")
 
       expect(subject.class.values_count_with_participated(user.encrypted_id)).to match_array([
         hash_including({
+          # A real reaction ID is only required/meaningful when the current user has reacted.
+          # Otherwise the value is meaningless.
+          id: reaction.id.to_s,
           value: ":smile:",
           count: 2,
           participated: true
         }),
         hash_including({
+          # id is not relevant here because the user did not react
           value: ":smirk:",
           count: 1,
           participated: false


### PR DESCRIPTION
This fixes removing emoji from posts. It extends the whitelist of HTTP verbs. Future work should consider whether allowing all origins is a good idea

Fixes #529 