### PR TITLE
Replace map-reduce with aggregation

### DIFF
--- a/backend/app/models/notification.rb
+++ b/backend/app/models/notification.rb
@@ -37,10 +37,10 @@ class Notification
     end
 
     def count_by_types
-      group = criteria.group(_id: "$kind", count: { "$sum": 1 })
+      group = criteria.group(_id: "$kind", count: {"$sum": 1})
       aggregate = collection.aggregate(group.pipeline)
       aggregate.reduce({}) { |acc, notification|
-        h = { notification["_id"] => notification["count"] }
+        h = {notification["_id"] => notification["count"]}
         acc.merge(h)
       }
     end

--- a/backend/app/models/notification.rb
+++ b/backend/app/models/notification.rb
@@ -5,35 +5,6 @@ class Notification
 
   after_initialize :set_defaults
 
-  ID = "_id".freeze
-  VALUE = "value".freeze
-  TOTAL = "total".freeze
-
-  MAP_COUNT = <<-JS.strip_heredoc.gsub(/\s+/, " ").freeze
-    function() {
-      emit(
-        this.kind,
-        {
-          total: 1,
-        }
-      );
-    }
-  JS
-
-  REDUCE_COUNT = <<-JS.strip_heredoc.gsub(/\s+/, " ").freeze
-    function(key, valuesGroup){
-      var r = {
-        total: 0,
-      };
-
-      for (var idx  = 0; idx < valuesGroup.length; idx++) {
-        r.total += valuesGroup[idx].total;
-      }
-
-      return r;
-    }
-  JS
-
   field :kind, type: String
   field :encrypted_user_id, type: String, encrypted: {type: :integer}
   field :encrypted_notify_user_id, type: String, encrypted: {type: :integer}
@@ -66,7 +37,12 @@ class Notification
     end
 
     def count_by_types
-      reduce_count.map { |n| [n[ID], n.dig(VALUE, TOTAL).to_i] }.to_h
+      group = criteria.group(_id: "$kind", count: { "$sum": 1 })
+      aggregate = collection.aggregate(group.pipeline)
+      aggregate.reduce({}) { |acc, notification|
+        h = { notification["_id"] => notification["count"] }
+        acc.merge(h)
+      }
     end
 
     def groupped_by_post_and_kind(encrypted_user_id)
@@ -76,10 +52,6 @@ class Notification
     end
 
     private
-
-    def reduce_count
-      map_reduce(MAP_COUNT, REDUCE_COUNT).out(inline: 1).to_a
-    end
 
     def normalized_notifications(group)
       group.map do |group_keys, notifications|

--- a/backend/spec/factories/comments.rb
+++ b/backend/spec/factories/comments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :comment do
+    body { "This is a comment." }
+    encrypted_user_id { create(:user).encrypted_id }
+    post_id { create(:post).id }
+  end
+end

--- a/backend/spec/factories/notifications.rb
+++ b/backend/spec/factories/notifications.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :notification do
+    kind { "reaction" }
+    notificateable { create(:post) }
+
+    encrypted_user_id { create(:user).encrypted_id }
+    encrypted_notify_user_id { create(:user).encrypted_id }
+
+    initialize_with { new(attributes) }
+  end
+end

--- a/backend/spec/models/notification_spec.rb
+++ b/backend/spec/models/notification_spec.rb
@@ -35,7 +35,7 @@ describe Notification do
       expect(Notification.all.count_by_types).to eq({
         "comment" => 2,
         "mention" => 2,
-        "reaction" => 4,
+        "reaction" => 4
       })
     end
   end

--- a/backend/spec/models/notification_spec.rb
+++ b/backend/spec/models/notification_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+describe Notification do
+  let(:alice) { create(:user) }
+  let(:bob) { create(:user) }
+
+  let(:first_post) { create(:post) }
+  let(:second_post) { create(:post) }
+
+  let(:comment_for_first_post) { create(:comment, post: first_post) }
+  let(:comment_for_second_post) { create(:comment, post: second_post) }
+
+  context "#count_by_types" do
+    it "should count all by kind" do
+      # The following are valid possibilities for (kind, notificateable_type):
+      # - ("comment", "Comment"): commenting on a post
+      # - ("mention", "Comment"): users can only mention other users who have commented in a post
+      # - ("reaction", "Post")
+      # - ("reaction", "Comment")
+
+      alice_id = alice.encrypted_id
+      bob_id = bob.encrypted_id
+
+      create(:notification, kind: "comment", notificateable: comment_for_first_post, encrypted_user_id: alice_id, encrypted_notify_user_id: bob_id)
+      create(:notification, kind: "comment", notificateable: comment_for_second_post, encrypted_user_id: alice_id, encrypted_notify_user_id: bob_id)
+
+      create(:notification, kind: "mention", notificateable: comment_for_first_post, encrypted_user_id: alice_id, encrypted_notify_user_id: bob_id)
+      create(:notification, kind: "mention", notificateable: comment_for_second_post, encrypted_user_id: alice_id, encrypted_notify_user_id: bob_id)
+
+      create(:notification, kind: "reaction", notificateable: first_post, encrypted_user_id: alice_id, encrypted_notify_user_id: bob_id)
+      create(:notification, kind: "reaction", notificateable: second_post, encrypted_user_id: alice_id, encrypted_notify_user_id: bob_id)
+      create(:notification, kind: "reaction", notificateable: comment_for_first_post, encrypted_user_id: alice_id, encrypted_notify_user_id: bob_id)
+      create(:notification, kind: "reaction", notificateable: comment_for_second_post, encrypted_user_id: alice_id, encrypted_notify_user_id: bob_id)
+
+      expect(Notification.all.count_by_types).to eq({
+        "comment" => 2,
+        "mention" => 2,
+        "reaction" => 4,
+      })
+    end
+  end
+end


### PR DESCRIPTION
The free tier and some other tiers of MongoDBaaS do not support map-reduce. In fact, according to https://docs.mongodb.com/manual/aggregation/#map-reduce, map-reduce should be replaced with the aggregation pipeline. This changeset does this for the last usage of map-reduce.

TODO
- [x] Complete the reimplementation of `count_by_types` without `map_reduce`
- [ ] Add more tests
- [x] Fix issue when using chat with [latest commit on master](https://github.com/rubyforgood/Flaredown/commit/25976d1a7be28d1c8766a246baf17e612b26bfb2): https://gist.github.com/codemonium/4723d382e867ce5bc6ebb51dee38f37d