### PR TITLE
Fix uninitialized constant issue

### DIFF
--- a/backend/app/serializers/api/v1/comment_serializer.rb
+++ b/backend/app/serializers/api/v1/comment_serializer.rb
@@ -1,8 +1,8 @@
 module Api
   module V1
     class CommentSerializer < ApplicationSerializer
-      include Notificatable
-      include ReactionRelatable
+      include Concerns::Notificatable
+      include Concerns::ReactionRelatable
 
       attributes :post_id, :body, :user_name, :postable_id, :type
 

--- a/backend/app/serializers/api/v1/concerns/notificatable.rb
+++ b/backend/app/serializers/api/v1/concerns/notificatable.rb
@@ -1,15 +1,17 @@
 module Api
   module V1
-    module Notificatable
-      extend ActiveSupport::Concern
+    module Concerns
+      module Notificatable
+        extend ActiveSupport::Concern
 
-      included do
-        attributes :notifications
-      end
+        included do
+          attributes :notifications
+        end
 
-      def notifications
-        return {} unless current_user
-        object.notifications.where(encrypted_notify_user_id: current_user.encrypted_id).count_by_types
+        def notifications
+          return {} unless current_user
+          object.notifications.where(encrypted_notify_user_id: current_user.encrypted_id).count_by_types
+        end
       end
     end
   end

--- a/backend/app/serializers/api/v1/concerns/reaction_relatable.rb
+++ b/backend/app/serializers/api/v1/concerns/reaction_relatable.rb
@@ -1,18 +1,20 @@
 module Api
   module V1
-    module ReactionRelatable
-      extend ActiveSupport::Concern
+    module Concerns
+      module ReactionRelatable
+        extend ActiveSupport::Concern
 
-      included do
-        attributes :reactions
-      end
+        included do
+          attributes :reactions
+        end
 
-      def reactions
-        ReactionSerializer.new(
-          object.reactions.values_count_with_participated(current_user&.encrypted_id),
-          object.id,
-          object.class.name
-        )
+        def reactions
+          ReactionSerializer.new(
+            object.reactions.values_count_with_participated(current_user&.encrypted_id),
+            object.id,
+            object.class.name
+          )
+        end
       end
     end
   end

--- a/backend/app/serializers/api/v1/concerns/topic_serializable.rb
+++ b/backend/app/serializers/api/v1/concerns/topic_serializable.rb
@@ -1,15 +1,17 @@
 module Api
   module V1
-    module TopicSerializable
-      extend ActiveSupport::Concern
+    module Concerns
+      module TopicSerializable
+        extend ActiveSupport::Concern
 
-      included do
-        attributes :id, :tag_ids, :symptom_ids, :condition_ids, :treatment_ids
+        included do
+          attributes :id, :tag_ids, :symptom_ids, :condition_ids, :treatment_ids
 
-        has_many :tags, embed_in_root: true
-        has_many :symptoms, embed_in_root: true
-        has_many :conditions, embed_in_root: true
-        has_many :treatments, embed_in_root: true
+          has_many :tags, embed_in_root: true
+          has_many :symptoms, embed_in_root: true
+          has_many :conditions, embed_in_root: true
+          has_many :treatments, embed_in_root: true
+        end
       end
     end
   end

--- a/backend/app/serializers/api/v1/post_serializer.rb
+++ b/backend/app/serializers/api/v1/post_serializer.rb
@@ -1,9 +1,9 @@
 module Api
   module V1
     class PostSerializer < ApplicationSerializer
-      include Notificatable
-      include TopicSerializable
-      include ReactionRelatable
+      include Concerns::Notificatable
+      include Concerns::TopicSerializable
+      include Concerns::ReactionRelatable
 
       attributes :id, :body, :title, :type, :user_name, :comments_count, :postable_id, :priority
 

--- a/backend/app/serializers/api/v1/topic_following_serializer.rb
+++ b/backend/app/serializers/api/v1/topic_following_serializer.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class TopicFollowingSerializer < ApplicationSerializer
-      include TopicSerializable
+      include Concerns::TopicSerializable
     end
   end
 end

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -34,6 +34,7 @@ module Flaredown
     config.autoload_paths << Rails.root.join("lib/*")
     config.autoload_paths << Rails.root.join("lib/**/*")
     config.autoload_paths << Rails.root.join("app/serializers/concerns")
+    config.autoload_paths << Rails.root.join("app/serializers/api/v1/concerns")
 
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.


### PR DESCRIPTION
This changeset resolves the issue shown in https://gist.github.com/codemonium/4723d382e867ce5bc6ebb51dee38f37d, reproducible when viewing the chat. E.g.,
```
uninitialized constant Api::V1::PostSerializer::Notificatable
```
Since we recently namespaced the serializers (https://github.com/rubyforgood/Flaredown/commit/25976d1a7be28d1c8766a246baf17e612b26bfb2), they were no longer able to find the concerns. The solution is to be more explicit when using the concerns.