### PR TITLE
Report staging exceptions to Bugsnag as such

### DIFF
--- a/backend/config/initializers/bugsnag.rb
+++ b/backend/config/initializers/bugsnag.rb
@@ -1,3 +1,4 @@
 Bugsnag.configure do |config|
   config.api_key = ENV["BUGSNAG_API_KEY"]
+  config.release_stage = ENV["BUGSNAG_RELEASE_STAGE"] || ENV["RAILS_ENV"]
 end


### PR DESCRIPTION
Staging runs using the `production` RAILS_ENV, so is currently indistinguishable from production in Bugsnag.

This is already configured in staging so will begin working when merged.

See https://docs.bugsnag.com/platforms/ruby/other/configuration-options/#release_stage