### PR TITLE
Fix creating new patterns

### DIFF
--- a/backend/app/controllers/api/v1/patterns_controller.rb
+++ b/backend/app/controllers/api/v1/patterns_controller.rb
@@ -25,7 +25,7 @@ module Api
       end
 
       def create
-        @pattern = PatternCreator.new(pattern_params).create
+        @pattern = PatternCreator.new(pattern_params.to_h).create
 
         render json: @pattern
       end


### PR DESCRIPTION
This is likely related to the Rails upgrade. When creating a new Pattern, the serializer is expecting a Hash, but was instead getting an `ActionController::Parameters` object. Since Mongo didn't know how to serialize that, it was throwing an HTTP 500 error like this:

```
BSON::Error::UnserializableClass - Value does not define its BSON serialized type: {"id"=>4853, "category"=>"foods", "label"=>"Soy flour, full-fat, roasted"}
```

Casting it to a hash makes it serializable.